### PR TITLE
Remove rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "slim"
 
 group :development do
   gem "foreman"
-  gem "onkcop", "0.42.0.1", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,15 +60,12 @@ GEM
     newrelic_rpm (3.17.2.327)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
-    onkcop (0.42.0.1)
-      rubocop (~> 0.42.0)
     parser (2.3.3.1)
       ast (~> 2.2)
     poltergeist (1.12.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    powerpack (0.1.1)
     proc_to_ast (0.1.0)
       coderay
       parser
@@ -84,7 +81,6 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rainbow (2.2.1)
     rollbar (2.14.0)
       multi_json
     rspec (3.5.0)
@@ -106,13 +102,6 @@ GEM
       rspec (>= 2.13, < 4)
       unparser
     rspec-support (3.5.0)
-    rubocop (0.42.0)
-      parser (>= 2.3.1.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -140,7 +129,6 @@ GEM
     tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (1.1.2)
     unparser (0.2.5)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
@@ -166,7 +154,6 @@ DEPENDENCIES
   foreman
   jemalloc
   newrelic_rpm
-  onkcop (= 0.42.0.1)
   puma
   puma_worker_killer
   rack-test
@@ -177,6 +164,9 @@ DEPENDENCIES
   sinatra (~> 2.0.0.beta2)
   sinatra-contrib (~> 2.0.0.beta2)
   slim
+
+RUBY VERSION
+   ruby 2.4.0p0
 
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
`gem install rainbow` is failure

```
$ bundle install

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/sue445/dev/workspace/github.com/sue445/app-stat-api/vendor/bundle/ruby/2.4.0/gems/rainbow-2.2.1/ext
/Users/sue445/.rbenv/versions/2.4.0/bin/ruby mkrf_conf.rb

current directory: /Users/sue445/dev/workspace/github.com/sue445/app-stat-api/vendor/bundle/ruby/2.4.0/gems/rainbow-2.2.1/ext
rake
RUBYARCHDIR=/Users/sue445/dev/workspace/github.com/sue445/app-stat-api/vendor/bundle/ruby/2.4.0/extensions/x86_64-darwin-13/2.4.0-static/rainbow-2.2.1
RUBYLIBDIR=/Users/sue445/dev/workspace/github.com/sue445/app-stat-api/vendor/bundle/ruby/2.4.0/extensions/x86_64-darwin-13/2.4.0-static/rainbow-2.2.1
/Users/sue445/.rbenv/versions/2.4.0/lib/ruby/2.4.0/rubygems.rb:270:in `find_spec_for_exe': can't find gem rake (>= 0.a)
(Gem::GemNotFoundException)
  from /Users/sue445/.rbenv/versions/2.4.0/lib/ruby/2.4.0/rubygems.rb:298:in `activate_bin_path'
  from /Users/sue445/.rbenv/versions/2.4.0/bin/rake:22:in `<main>'

rake failed, exit code 1

Gem files will remain installed in /Users/sue445/dev/workspace/github.com/sue445/app-stat-api/vendor/bundle/ruby/2.4.0/gems/rainbow-2.2.1
for inspection.
Results logged to
/Users/sue445/dev/workspace/github.com/sue445/app-stat-api/vendor/bundle/ruby/2.4.0/extensions/x86_64-darwin-13/2.4.0-static/rainbow-2.2.1/gem_make.out

An error occurred while installing rainbow (2.2.1), and Bundler cannot continue.
Make sure that `gem install rainbow -v '2.2.1'` succeeds before bundling.
```