### PR TITLE
Use https://www.apple.com instead of http://www.apple.com

### DIFF
--- a/spec/config/countries_spec.rb
+++ b/spec/config/countries_spec.rb
@@ -7,7 +7,8 @@ describe "config/countries.yml" do
 
   with_them do
     it "url is available" do
-      http = Net::HTTP.new("www.apple.com")
+      http = Net::HTTP.new("www.apple.com", 443)
+      http.use_ssl = true
       response = http.head("/#{country}/support/systemstatus/")
       expect(response.code).to eq "200"
     end


### PR DESCRIPTION
http redirected to https

spec result

```
Failures:

  1) config/countries.yml country: "cn" url is available
     Failure/Error: expect(response.code).to eq "200"

       expected: "200"
            got: "301"

       (compared using ==)
     # ./spec/config/countries_spec.rb:12:in `block (3 levels) in <top (required)>'
```

curl

```
$ curl -I http://www.apple.com/cn/support/systemstatus/
HTTP/1.1 301 Moved Permanently
Server: AkamaiGHost
Content-Length: 0
Location: https://www.apple.com/cn/support/systemstatus/
Cache-Control: max-age=0
Expires: Sun, 16 Apr 2017 14:55:07 GMT
Date: Sun, 16 Apr 2017 14:55:07 GMT
Connection: keep-alive
X-N: S
```