### PR TITLE
Tweak error message 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,5 @@ group :test do
   gem "codeclimate-test-reporter", require: false
   gem "rack-test"
   gem "rspec"
-  gem "rspec-parameterized"
   gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    abstract_type (0.0.7)
     activesupport (5.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    adamantium (0.2.0)
-      ice_nine (~> 0.11.0)
-      memoizable (~> 0.4.0)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     apple_system_status (0.3.0)
@@ -17,10 +13,7 @@ GEM
       capybara
       poltergeist
       thor
-    ast (2.3.0)
     backports (3.8.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     capybara (2.14.0)
       addressable
       mime-types (>= 1.16)
@@ -31,25 +24,16 @@ GEM
     cliver (0.3.2)
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
-    coderay (1.1.1)
-    concord (0.1.5)
-      adamantium (~> 0.2.0)
-      equalizer (~> 0.0.9)
     concurrent-ruby (1.0.5)
     dalli (2.7.6)
-    debug_inspector (0.0.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    equalizer (0.0.11)
     foreman (0.84.0)
       thor (~> 0.19.1)
     get_process_mem (0.2.1)
     i18n (0.8.1)
-    ice_nine (0.11.2)
     jemalloc (1.0.1)
     json (2.1.0)
-    memoizable (0.4.2)
-      thread_safe (~> 0.3, >= 0.3.1)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -60,17 +44,10 @@ GEM
     newrelic_rpm (4.2.0.334)
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
-    parser (2.3.3.1)
-      ast (~> 2.2)
     poltergeist (1.15.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    proc_to_ast (0.1.0)
-      coderay
-      parser
-      unparser
-    procto (0.0.3)
     public_suffix (2.0.5)
     puma (3.8.2)
     puma_worker_killer (0.1.0)
@@ -95,12 +72,6 @@ GEM
     rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
-    rspec-parameterized (0.3.2)
-      binding_of_caller
-      parser
-      proc_to_ast
-      rspec (>= 2.13, < 4)
-      unparser
     rspec-support (3.6.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
@@ -128,14 +99,6 @@ GEM
     tilt (2.0.7)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    unparser (0.2.5)
-      abstract_type (~> 0.0.7)
-      adamantium (~> 0.2.0)
-      concord (~> 0.1.5)
-      diff-lcs (~> 1.2.5)
-      equalizer (~> 0.0.9)
-      parser (~> 2.3.0)
-      procto (~> 0.0.2)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -158,11 +121,13 @@ DEPENDENCIES
   rack-test
   rollbar
   rspec
-  rspec-parameterized
   simplecov
   sinatra (>= 2.0.0)
   sinatra-contrib (>= 2.0.0)
   slim
+
+RUBY VERSION
+   ruby 2.4.1p111
 
 BUNDLED WITH
    1.14.6

--- a/spec/config/countries_spec.rb
+++ b/spec/config/countries_spec.rb
@@ -1,12 +1,10 @@
 require "uri/https"
 
 describe "config/countries.yml" do
-  where(:country) do
-    YAML.load_file("#{app_dir}/config/countries.yml").map { |c| c["code"] }.reject { |code| code == "us" }.product
-  end
+  countries = YAML.load_file("#{app_dir}/config/countries.yml").map { |c| c["code"] }.reject { |code| code == "us" }
 
-  with_them do
-    it "url is available" do
+  countries.each do |country|
+    it "https://www.apple.com/#{country}/support/systemstatus/ is available" do
       http = Net::HTTP.new("www.apple.com", 443)
       http.use_ssl = true
       response = http.head("/#{country}/support/systemstatus/")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,6 @@ end
 
 require "rspec"
 require "rack/test"
-require "rspec-parameterized"
 require_relative "../app"
 
 ENV["RACK_ENV"] = "test"


### PR DESCRIPTION

```
  1) config/countries.yml https://www.apple.com/pt/support/systemstatus/ is available
     Failure/Error: expect(response.code).to eq "200"

       expected: "200"
            got: "403"

       (compared using ==)
     # ./spec/config/countries_spec.rb:11:in `block (3 levels) in <top (required)>'
```