### PR TITLE
Use browsers-legacy instead of browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 
 default: &default
   docker:
-    - image: circleci/ruby:2.5.1-browsers
+    - image: circleci/ruby:2.5.1-browsers-legacy
       environment:
         RACK_ENV: test
         CODECLIMATE_REPO_TOKEN: 4b2a7d452fe78268da978f159e06bfe6a7749aeb875ab3d93ca37dfc799bd3dc


### PR DESCRIPTION
Now, `phantomjs` is removed from `circleci/ruby:2.5.1-browsers`

https://github.com/CircleCI-Public/circleci-dockerfiles/commit/a5eeaa0c1a95c7ec783fff0cbad7e33a70d82a6b#diff-707a1aa51b4371b141c88e119055f265L24

So I use `phantomjs` in `circleci/ruby:2.5.1-browsers-legacy`
https://github.com/CircleCI-Public/circleci-dockerfiles/blob/d35c9c1452bc0d3a97bd2a435726286eec0b5407/ruby/images/2.5.1-stretch/browsers-legacy/Dockerfile#L22-L30